### PR TITLE
Corrected length of start signal for DHT22.

### DIFF
--- a/DHT22.c
+++ b/DHT22.c
@@ -42,7 +42,7 @@ void DHT22CycleIdle(void)
 {
  unsigned short _temp;
 
-if(Timerms > 1000)  // more than 1000ms
+ if (Timerms > DHT22_MS_BETWEEN_CONV) // more than 2000ms (oryginal 1000ms)
  {
    // ok Half second pass 
    // time to start pulse
@@ -84,8 +84,8 @@ if(Timerms > 1000)  // more than 1000ms
 
 void DHT22CycleStart(void)
 {
-  // wait until Timerms got at least 2ms (2 counts).
-  if(Timerms >2)
+  // wait until Timerms got sligtly less than 2ms (2 counts).
+  if (Timerms > DHT22_MS_BETWEEN_CONV+2)
   {
     // release for 
      if(CurrentIOPin == 0)

--- a/DHT22.h
+++ b/DHT22.h
@@ -4,7 +4,7 @@
 
 
 #define DHT22_BIT_COUNT         40
-
+#define DHT22_MS_BETWEEN_CONV   2000
        
 
 extern void DoDHT22Cycle(void);

--- a/RCServo.c
+++ b/RCServo.c
@@ -14,89 +14,98 @@ unsigned char ServoIndex;
 volatile unsigned short CurrentServoTimer;
 unsigned short ServoTimer[INPUT_COUNT];
 
+unsigned int ServoTimerDeadTime=SERVO_REFRESCH_PERIOD;
 
-void RCServoISR(void)
-{
+void RCServoISR(void) {
+    
+    TMR1ON = 0;
+    TMR1IF = 0;
+    
+    if (ServoTimeOutFlag) {
+        if (ServoIndex == 0)
+            IO0 = 0;
+        else if (ServoIndex == 1)
+            IO1 = 0;
+    }
+    
+    do {
+        ServoIndex++;
+        if (ServoIndex > INPUT_COUNT) {
+            ServoIndex = 0;
+            ServoTimerDeadTime=SERVO_REFRESCH_PERIOD;
+        }
+    } while ((Setting.IOConfig[ServoIndex] != IOCONFIG_SERVO) && (ServoIndex<INPUT_COUNT));
+    
+    if (ServoIndex<INPUT_COUNT) ServoTimerDeadTime -= ServoTimer[ServoIndex];
 
-if(ServoTimeOutFlag)
-{
-    if(ServoIndex==0)
-        IO0=0;
-    else if(ServoIndex==1)
-        IO1=0;
-}
-    ServoIndex++;
-    if(ServoIndex>INPUT_COUNT)
-    ServoIndex=0;
-
-    TMR1ON=0;
-    TMR1IF=0;
-    if(ServoIndex==INPUT_COUNT)
-        CurrentServoTimer=12000;
-    else
+    if (ServoIndex == INPUT_COUNT)
+        CurrentServoTimer = ServoTimerDeadTime;
+//          CurrentServoTimer = 16500;
+    else        
         CurrentServoTimer = ServoTimer[ServoIndex];
-    if(CurrentServoTimer==0)
-    {
-    ServoTimeOutFlag=0;
-    TMR1= 64536;
+    
+    if (CurrentServoTimer == 0) {
+        ServoTimeOutFlag = 0;
+        TMR1 = 64536;
+    } else {
+        ServoTimeOutFlag = 1;
+        TMR1 = (~CurrentServoTimer) + 1;
     }
-    else
-    {
-        ServoTimeOutFlag=1;
-        TMR1 = (~CurrentServoTimer)+1;
-    }
-    TMR1ON=1;
-    if(ServoIndex==0)
-        IO0=1;
-    else if(ServoIndex==1)
-        IO1=1;
+    
+    TMR1ON = 1;
+    if (ServoIndex == 0)
+        IO0 = 1;
+    else if (ServoIndex == 1)
+        IO1 = 1;
 }
 
-
-void DoRCServo(void)
-{
+void DoRCServo(void) {
     unsigned char loop;
-    unsigned char flag=0;
-    unsigned short _temp;
+    unsigned char flag = 0;
+    unsigned short _temp_time, _temp_index;
+    
+    for (loop = 0; loop < INPUT_COUNT; loop++)
+        if (Setting.IOConfig[loop] == IOCONFIG_SERVO) {
+            
+            //Normalize on periods
+            if (ServoTimer[loop] < SERVO_MIN_ACTIVE_TIME) {
+                ServoTimer[loop] = SERVO_MIN_ACTIVE_TIME;
+            }
+            if (ServoTimer[loop] > SERVO_MAX_ACTIVE_TIME) {
+                ServoTimer[loop] = SERVO_MAX_ACTIVE_TIME;
+            } 
+            flag++;
+            if (flag==1) {
+                _temp_time = ServoTimer[loop];
+                _temp_index = loop;
+            }
+        }
 
-
-    _temp= 16000;
-    for(loop=0;loop < INPUT_COUNT;loop++)
-        if(Setting.IOConfig[loop] == IOCONFIG_SERVO)
-          {
-            flag=1;
-            _temp -= ServoTimer[loop];
-          }
-
-  //  ServoTimer[3]=_temp;
-    if(flag)
-    {
-       if(TMR1ON==0)
-       {
-         //need to turn timer on
-           ServoIndex=0;
-
-           TMR1 = (~_temp)+1;
+    if (flag) {
+        if (TMR1ON == 0) {
+            //need to turn timer on
+            ServoIndex = _temp_index;
+            ServoTimerDeadTime=SERVO_REFRESCH_PERIOD - _temp_index;
+            
+            TMR1 = (~_temp_time) + 1;
 #if _XTAL_FREQ == 16000000
-           T1CON = 0b00100000;  // fsoc/4/4  (1Mhz timer clock)
+            T1CON = 0b00100000; // fsoc/4/4  (1Mhz timer clock)
 #else
-           // assume 32Mhz clock
-           T1CON = 0b00110000;  // fsoc/4/8  (1Mhz timer clock)
+            // assume 32Mhz clock
+            T1CON = 0b00110000; // fsoc/4/8  (1Mhz timer clock)
 #endif
-           TMR1GE=0;
-           TMR1IF=0;
-           TMR1IE=1;
-           TMR1ON=1;
+            TMR1GE = 0;
+            TMR1IF = 0;
+            TMR1IE = 1;
+            TMR1ON = 1;
 
-       }
+        }
 
 
-    }
-    else
-    {
-        TMR1ON=0;
-        TMR1IF=0;
-        TMR1IE=0;
+    } else {
+        TMR1ON = 0;
+        TMR1IF = 0;
+        TMR1IE = 0;
     }
 
 }

--- a/RCServo.h
+++ b/RCServo.h
@@ -20,6 +20,10 @@ extern unsigned char ServoIndex;
 extern volatile unsigned short CurrentServoTimer;
 extern unsigned short ServoTimer[INPUT_COUNT];
 
+#define SERVO_REFRESCH_PERIOD 20000 //us
+#define SERVO_MAX_ACTIVE_TIME 2500  //us
+#define SERVO_MIN_ACTIVE_TIME 500   //us
+
 /*
  * Servo Index
  *

--- a/main.c
+++ b/main.c
@@ -136,7 +136,7 @@
 
 
 #define SOFTWARE_ID      0x6532
-#define RELEASE_VERSION 0x0100
+#define RELEASE_VERSION 0x0101
 
 ///////////////////  How to program the IC.
 //


### PR DESCRIPTION
When I was testing original source using AM2302 I had, from time to time, conversions errors. So I connected my scope to data-line. The start signal was very short I don't remember now but it was about 20-40us and my AM2302 doesn't start transmission in return. In code is comment that intention was to generate 2ms impulse. But the same variable is used to count 1s spacing between conversions so the condition is always fulfilled. Corrected code is nearly the same only slightly modified. 
Additionally I expanded spacing between successive conversions from 1 second to 2 seconds, base on AM2302 documentation, now it is included in #define. But 1s spacing was working fine for me.